### PR TITLE
Corrected level inspection popups

### DIFF
--- a/scripts/user_interface/level_button.gd
+++ b/scripts/user_interface/level_button.gd
@@ -37,25 +37,26 @@ func _init() -> void:
 
 
 func _pressed() -> void:
-	if !GameManager.level_inspect:
-		match _level_group:
-			GlobalConst.LevelGroup.MAIN:
+	match _level_group:
+		GlobalConst.LevelGroup.MAIN:
+			if !GameManager.level_inspect:
 				var inspect_instance = LEVEL_INSPECT.instantiate()
 				get_tree().root.add_child(inspect_instance)
 				GameManager.level_inspect = inspect_instance
 				_toggle_connection.call_deferred(true)
 
-				GameManager.level_inspect.init_inspector.call_deferred(_level_name, _progress)
-				GameManager.change_state.call_deferred(GlobalConst.GameState.LEVEL_INSPECT)
+			GameManager.level_inspect.init_inspector.call_deferred(_level_name, _progress)
+			GameManager.change_state.call_deferred(GlobalConst.GameState.LEVEL_INSPECT)
 
-			GlobalConst.LevelGroup.CUSTOM:
+		GlobalConst.LevelGroup.CUSTOM:
+			if !GameManager.custom_inspect:
 				var inspect_instance = CUSTOM_LEVEL_INSPECT.instantiate()
 				get_tree().root.add_child(inspect_instance)
 				GameManager.custom_inspect = inspect_instance
 				_toggle_connection.call_deferred(true)
 
-				GameManager.custom_inspect.init_inspector.call_deferred(_level_name, _progress)
-				GameManager.change_state.call_deferred(GlobalConst.GameState.CUSTOM_LEVEL_INSPECT)
+			GameManager.custom_inspect.init_inspector.call_deferred(_level_name, _progress)
+			GameManager.change_state.call_deferred(GlobalConst.GameState.CUSTOM_LEVEL_INSPECT)
 
 
 func _get_minimum_size() -> Vector2:

--- a/scripts/user_interface/level_inspect.gd
+++ b/scripts/user_interface/level_inspect.gd
@@ -31,6 +31,7 @@ func init_inspector(level_name: String, progress: LevelProgress):
 		percentage = 0
 
 	level_score_img.material.set_shader_parameter("percentage", percentage)
+
 	build_btn.disabled = !progress.is_completed
 	_update_buttons(progress.is_unlocked)
 

--- a/scripts/user_interface/level_ui.gd
+++ b/scripts/user_interface/level_ui.gd
@@ -48,6 +48,8 @@ func _on_state_change(new_state: GlobalConst.GameState) -> void:
 			self.queue_free.call_deferred()
 		GlobalConst.GameState.LEVEL_INSPECT:
 			self.show()
+		GlobalConst.GameState.CUSTOM_LEVEL_INSPECT:
+			self.show()
 		GlobalConst.GameState.LEVEL_PICK:
 			self.show()
 		_:


### PR DESCRIPTION
Handled correctly level inspection popup by fixing a bug that caused the custom level inspection to be always created and level inspect itself to be only shown once until hard refresh. This closes #19.