### PR TITLE
Cleared state after saved a level

### DIFF
--- a/scripts/user_interface/builder_save.gd
+++ b/scripts/user_interface/builder_save.gd
@@ -28,6 +28,12 @@ func _on_state_change(new_state: GlobalConst.GameState) -> void:
 		GlobalConst.GameState.MAIN_MENU:
 			self.queue_free.call_deferred()
 		GlobalConst.GameState.BUILDER_SAVE:
+			_invalid_moves = true
+			_invalid_name = true
+			level_name.text = ""
+			level_name.caret_column = 0
+			moves.text = ""
+			moves.caret_column = 0
 			self.visible = true
 		_:
 			self.visible = false


### PR DESCRIPTION
Resetted fields after saving a game to show a clean state whenever player tries to save multiple levels. This closes #29.