### PR TITLE
Fix/#66

### DIFF
--- a/packed_scene/user_interface/LevelImport.tscn
+++ b/packed_scene/user_interface/LevelImport.tscn
@@ -120,6 +120,7 @@ theme_override_colors/icon_focus_color = Color(0.784314, 0, 0, 1)
 theme_override_colors/icon_pressed_color = Color(1, 0, 0, 1)
 theme_override_colors/icon_hover_color = Color(1, 0, 0, 1)
 theme_override_colors/icon_hover_pressed_color = Color(1, 0, 0, 1)
+disabled = true
 icon = SubResource("CompressedTexture2D_8n8sy")
 flat = true
 

--- a/scripts/user_interface/builder_save.gd
+++ b/scripts/user_interface/builder_save.gd
@@ -44,6 +44,7 @@ func _on_state_change(new_state: GlobalConst.GameState) -> void:
 			level_name.caret_column = 0
 			moves.text = ""
 			moves.caret_column = 0
+			_check_valid_info()
 			self.visible = true
 		_:
 			self.visible = false

--- a/scripts/user_interface/level_import.gd
+++ b/scripts/user_interface/level_import.gd
@@ -75,8 +75,10 @@ func _on_level_name_text_changed(new_text: String) -> void:
 func _update_save_btn() -> void:
 	if code.text == "" or level_name.text == "":
 		save_btn.disabled = true
+		persist_btn.disabled = true
 	else:
 		save_btn.disabled = false
+		persist_btn.disabled = false
 
 
 func _on_state_change(new_state: GlobalConst.GameState) -> void:
@@ -95,6 +97,7 @@ func _on_state_change(new_state: GlobalConst.GameState) -> void:
 
 func _show_error() -> void:
 	save_btn.disabled = true
+	persist_btn.disabled = true
 	code.add_theme_stylebox_override("normal", BUTTON_ERROR)
 	code.add_theme_color_override("icon_normal_color", Color.DARK_RED)
 	code.add_theme_color_override("font_color", Color.DARK_RED)

--- a/scripts/user_interface/level_ui.gd
+++ b/scripts/user_interface/level_ui.gd
@@ -85,7 +85,7 @@ func update_content() -> void:
 				level_btn_count -= 1
 			else:
 				level_button = LevelButton.new()
-				level_button.on_delete_level_button.connect(update_content)
+				level_button.on_delete_level_button.connect(_on_level_deleted)
 				_level_buttons.append(level_button)
 				level_grid.add_child(level_button)
 
@@ -103,6 +103,11 @@ func update_content() -> void:
 				_placeholder_buttons.append(placeholder_button)
 				level_grid.add_child(placeholder_button)
 			placeholder_button.construct(_world == GlobalConst.LevelGroup.CUSTOM)
+
+
+func _on_level_deleted(ref: LevelButton) -> void:
+	_level_buttons.erase(ref)
+	update_content()
 
 
 func _on_left_pressed() -> void:
@@ -138,9 +143,9 @@ func _on_world_btn_pressed() -> void:
 	_world = GlobalConst.LevelGroup.MAIN
 	_current_page = 1
 	_num_pages = ceil(float(GameManager.get_num_levels(_world)) / PAGE_SIZE)
-	update_content()
 	world_underline.show()
 	custom_underline.hide()
+	update_content()
 
 
 func _on_custom_btn_pressed() -> void:


### PR DESCRIPTION
persistent save button in Import UI not disabled when labels are empty
remove one custom level create a hole in the grid
if remove one custom level and switch in world levels the grid don't update correctly
after save level in editor don't disable save button