### PR TITLE
fix: cleared panel information after level completion

### DIFF
--- a/packed_scene/user_interface/LevelEnd.tscn
+++ b/packed_scene/user_interface/LevelEnd.tscn
@@ -16,6 +16,7 @@ shader_parameter/base_color = Color(0.992157, 0.937255, 0.768627, 1)
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_a3ofu"]
 shader = ExtResource("6_211iv")
 shader_parameter/percentage = 0.635
+shader_parameter/right_to_left = false
 
 [node name="LevelEnd" type="Control"]
 layout_mode = 3
@@ -87,7 +88,6 @@ layout_mode = 2
 size_flags_vertical = 8
 theme = ExtResource("7_dngta")
 theme_override_font_sizes/font_size = 26
-text = "Star-studded victory!"
 
 [node name="BottomRightContainer" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/scripts/user_interface/level_end.gd
+++ b/scripts/user_interface/level_end.gd
@@ -14,7 +14,6 @@ var _has_next_level: bool
 
 
 func _ready():
-	hint.text = ""
 	GameManager.on_state_change.connect(_on_state_change)
 
 	self.scale = GameManager.ui_scale
@@ -61,7 +60,8 @@ func _animate_stars(move_left: int) -> void:
 
 func _animate_hint(move_left: int):
 	hint.text = _select_random_text(move_left)
-	var tween = create_tween()
+	var tween := create_tween()
+
 	tween.set_ease(Tween.EASE_OUT)
 	tween.set_trans(Tween.TRANS_CUBIC)
 
@@ -94,20 +94,17 @@ func _play_frames(start_frame: int, end_frame: int, delay: float) -> void:
 
 func _on_replay_btn_pressed():
 	AudioManager.play_click_sound()
-	_play_frames(0, 1, 0.02)
-	_update_shader_percentage(0)
-	hint.text = ""
+
 	restart_level.emit()
+	queue_free()
 
 
 func _on_next_btn_pressed():
 	AudioManager.play_click_sound()
-	_play_frames(0, 1, 0.02)
-	_update_shader_percentage(0)
-	hint.text = ""
 
 	if !_has_next_level:
 		GameManager.change_state(GlobalConst.GameState.MAIN_MENU)
 	else:
 		var level: LevelData = GameManager.get_next_level()
 		GameManager.level_manager.init_level.call_deferred(level)
+		queue_free()


### PR DESCRIPTION
Corrected an issue that caused star and text animation to no be correctly reset. This behavior has been corrected by clearing the window completely. Using Tween::stop method was not enough as well as animating Sprite to frame 0.