### PR TITLE
Solved an issue that caused auomatic slider to be blocked middle way if an opposite direction automatic slider was triggered

### DIFF
--- a/packed_scene/scene_2d/LevelManager.tscn
+++ b/packed_scene/scene_2d/LevelManager.tscn
@@ -1,9 +1,22 @@
-[gd_scene load_steps=2 format=3 uid="uid://bqii2e6dq0dmu"]
+[gd_scene load_steps=3 format=3 uid="uid://bqii2e6dq0dmu"]
 
 [ext_resource type="Script" path="res://scripts/scene_2d/level_manager.gd" id="1_lxew3"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_uc548"]
 
 [node name="LevelManager" type="Node2D"]
 script = ExtResource("1_lxew3")
 
 [node name="Grid" type="Node2D" parent="."]
 unique_name_in_owner = true
+
+[node name="PlayableArea" type="Area2D" parent="."]
+unique_name_in_owner = true
+collision_layer = 2
+collision_mask = 0
+
+[node name="Collider" type="CollisionShape2D" parent="PlayableArea"]
+unique_name_in_owner = true
+shape = SubResource("RectangleShape2D_uc548")
+
+[connection signal="input_event" from="PlayableArea" to="." method="_on_playable_area_input_event"]

--- a/packed_scene/scene_2d/SliderArea.tscn
+++ b/packed_scene/scene_2d/SliderArea.tscn
@@ -50,16 +50,6 @@ unique_name_in_owner = true
 position = Vector2(0, -64)
 texture = ExtResource("6_woupr")
 
-[node name="Handle" type="Area2D" parent="."]
-unique_name_in_owner = true
-position = Vector2(128, 0)
-collision_layer = 2
-collision_mask = 2
-
-[node name="CollisionShape" type="CollisionPolygon2D" parent="Handle"]
-unique_name_in_owner = true
-polygon = PackedVector2Array(0, -110, 110, 0, 0, 110, -110, 0)
-
 [node name="Ray" type="RayCast2D" parent="."]
 unique_name_in_owner = true
 position = Vector2(128, 0)
@@ -69,4 +59,6 @@ hit_from_inside = true
 collide_with_areas = true
 collide_with_bodies = false
 
-[connection signal="input_event" from="Handle" to="." method="_on_handle_input_event"]
+[node name="Handle" type="Node2D" parent="."]
+unique_name_in_owner = true
+position = Vector2(110, 0)


### PR DESCRIPTION
Reworked logic that handles slider collision detection and user action to avoid any multiple sliders issues including two sliders blocking each other and multiple slider selection that could accidentally happen with touch.

- Level manager manages player iterations instead of sliders individually;
- Removed colliders and physics iterations from the slider;
- Refactor and clean up the code to introduce the new changes;