### PR TITLE
Add notify site workflow

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,0 +1,17 @@
+name: Notify site of new release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger site rebuild
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.SITE_REPO_PAT }}" \
+            https://api.github.com/repos/StampedeStudios/sum-zero-site/dispatches \
+            -d '{"event_type": "release-published"}'


### PR DESCRIPTION
## Description
<!-- Clearly describe what your PR does, including motivation and context. -->

This pr adds a workflow to notify the [site](https://github.com/StampedeStudios/sum-zero-site) to trigger a rebuild when this repo publishes a new release. In this way the site stays always up to date without any need to fetch github release in real time.

When a release is published we trigger the following [action](https://github.com/StampedeStudios/sum-zero-site/blob/main/.github/workflows/static.yml)

## Notes for Reviewers
We need to find a way to test this

